### PR TITLE
Upgrades for modules, plugins, SBT.

### DIFF
--- a/scala_29/lift_basic/build.sbt
+++ b/scala_29/lift_basic/build.sbt
@@ -17,11 +17,11 @@ unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp"
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5-RC2"
+  val liftVersion = "2.5-RC4"
   Seq(
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
     "net.liftweb"       %% "lift-mapper"        % liftVersion        % "compile",
-    "net.liftmodules"   %% "lift-jquery-module" % (liftVersion + "-2.2"),
+    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.3",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_29/lift_basic/project/build.properties
+++ b/scala_29/lift_basic/project/build.properties
@@ -1,0 +1,2 @@
+sbt.version=0.12.2
+

--- a/scala_29/lift_basic/project/plugins.sbt
+++ b/scala_29/lift_basic/project/plugins.sbt
@@ -3,12 +3,11 @@ libraryDependencies <+= sbtVersion(v => v match {
   case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
   case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
   case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case "0.12.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-  case "0.12.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
+  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
 })
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.2.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")

--- a/scala_29/lift_blank/build.sbt
+++ b/scala_29/lift_blank/build.sbt
@@ -17,10 +17,10 @@ unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp"
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5-RC2"
+  val liftVersion = "2.5-RC4"
   Seq(
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
-    "net.liftmodules"   %% "lift-jquery-module" % (liftVersion + "-2.2"),
+    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.3",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_29/lift_blank/project/build.properties
+++ b/scala_29/lift_blank/project/build.properties
@@ -1,0 +1,2 @@
+sbt.version=0.12.2
+

--- a/scala_29/lift_blank/project/plugins.sbt
+++ b/scala_29/lift_blank/project/plugins.sbt
@@ -3,13 +3,11 @@ libraryDependencies <+= sbtVersion(v => v match {
   case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
   case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
   case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case "0.12.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-  case "0.12.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
+  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
 })
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.2.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")
-
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")

--- a/scala_29/lift_json/build.sbt
+++ b/scala_29/lift_json/build.sbt
@@ -13,7 +13,7 @@ resolvers ++= Seq("snapshots"     at "http://oss.sonatype.org/content/repositori
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5-RC2"
+  val liftVersion = "2.5-RC4"
   Seq(
     "net.liftweb"       %% "lift-json"          % liftVersion        % "compile",
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_29/lift_json/project/build.properties
+++ b/scala_29/lift_json/project/build.properties
@@ -1,0 +1,2 @@
+sbt.version=0.12.2
+

--- a/scala_29/lift_json/project/plugins.sbt
+++ b/scala_29/lift_json/project/plugins.sbt
@@ -3,12 +3,11 @@ libraryDependencies <+= sbtVersion(v => v match {
   case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
   case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
   case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case "0.12.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-  case "0.12.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
+  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
 })
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.2.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")

--- a/scala_29/lift_mvc/build.sbt
+++ b/scala_29/lift_mvc/build.sbt
@@ -17,11 +17,11 @@ unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp"
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5-RC2"
+  val liftVersion = "2.5-RC4"
   Seq(
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
     "net.liftweb"       %% "lift-mapper"        % liftVersion        % "compile",
-    "net.liftmodules"   %% "lift-jquery-module" % (liftVersion + "-2.2"),
+    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.3",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_29/lift_mvc/project/build.properties
+++ b/scala_29/lift_mvc/project/build.properties
@@ -1,0 +1,2 @@
+sbt.version=0.12.2
+

--- a/scala_29/lift_mvc/project/plugins.sbt
+++ b/scala_29/lift_mvc/project/plugins.sbt
@@ -3,12 +3,11 @@ libraryDependencies <+= sbtVersion(v => v match {
   case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
   case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
   case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case "0.12.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-  case "0.12.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
+  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
 })
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.2.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")


### PR DESCRIPTION
I've touched all the example project to...
- Add support for SBT 0.12.2 (build.properties added, web plugin dependency changed)
- Upgraded Eclipse and IntelliJ plugins to latest versions
- USe Lift 2.5-M4
- Switched jquery module to use the new _.2.5 naming scheme.

BTW, I noticed that the lift_json project doesn't contain a runnable web application. Not sure why this is.
