### PR TITLE
Version bumps and fix for unit test.

### DIFF
--- a/scala_210/lift_basic/build.sbt
+++ b/scala_210/lift_basic/build.sbt
@@ -11,18 +11,18 @@ resolvers ++= Seq("snapshots"     at "http://oss.sonatype.org/content/repositori
                   "releases"      at "http://oss.sonatype.org/content/repositories/releases"
                  )
 
-seq(com.github.siasia.WebPlugin.webSettings :_*)
+seq(webSettings :_*)
 
 unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp" }
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5"
+  val liftVersion = "2.5.1"
   Seq(
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
     "net.liftweb"       %% "lift-mapper"        % liftVersion        % "compile",
-    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.3",
+    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_210/lift_basic/project/build.properties
+++ b/scala_210/lift_basic/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.12.2
+sbt.version=0.12.4
 

--- a/scala_210/lift_basic/project/plugins.sbt
+++ b/scala_210/lift_basic/project/plugins.sbt
@@ -1,13 +1,7 @@
-libraryDependencies <+= sbtVersion(v => v match {
-  case "0.11.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.0-0.2.8"
-  case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
-  case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
-  case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-})
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.3.0")
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")

--- a/scala_210/lift_blank/build.sbt
+++ b/scala_210/lift_blank/build.sbt
@@ -10,17 +10,17 @@ resolvers ++= Seq("snapshots"     at "http://oss.sonatype.org/content/repositori
                 "releases"        at "http://oss.sonatype.org/content/repositories/releases"
                 )
 
-seq(com.github.siasia.WebPlugin.webSettings :_*)
+seq(webSettings :_*)
 
 unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp" }
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5"
+  val liftVersion = "2.5.1"
   Seq(
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
-    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.3",
+    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_210/lift_blank/project/build.properties
+++ b/scala_210/lift_blank/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.12.2
+sbt.version=0.12.4
 

--- a/scala_210/lift_blank/project/plugins.sbt
+++ b/scala_210/lift_blank/project/plugins.sbt
@@ -1,13 +1,7 @@
-libraryDependencies <+= sbtVersion(v => v match {
-  case "0.11.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.0-0.2.8"
-  case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
-  case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
-  case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-})
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.3.0")
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")

--- a/scala_210/lift_json/build.sbt
+++ b/scala_210/lift_json/build.sbt
@@ -13,7 +13,7 @@ resolvers ++= Seq("snapshots"     at "http://oss.sonatype.org/content/repositori
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5"
+  val liftVersion = "2.5.1"
   Seq(
     "net.liftweb"       %% "lift-json"          % liftVersion % "compile",
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_210/lift_json/project/build.properties
+++ b/scala_210/lift_json/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.12.2
+sbt.version=0.12.4
 

--- a/scala_210/lift_json/project/plugins.sbt
+++ b/scala_210/lift_json/project/plugins.sbt
@@ -1,13 +1,7 @@
-libraryDependencies <+= sbtVersion(v => v match {
-  case "0.11.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.0-0.2.8"
-  case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
-  case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
-  case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-})
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.3.0")
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")

--- a/scala_210/lift_mvc/build.sbt
+++ b/scala_210/lift_mvc/build.sbt
@@ -10,18 +10,18 @@ resolvers ++= Seq("snapshots"     at "http://oss.sonatype.org/content/repositori
                 "releases"        at "http://oss.sonatype.org/content/repositories/releases"
                 )
 
-seq(com.github.siasia.WebPlugin.webSettings :_*)
+seq(webSettings :_*)
 
 unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp" }
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5"
+  val liftVersion = "2.5.1"
   Seq(
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
     "net.liftweb"       %% "lift-mapper"        % liftVersion        % "compile",
-    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.3",
+    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_210/lift_mvc/project/build.properties
+++ b/scala_210/lift_mvc/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.12.2
+sbt.version=0.12.4
 

--- a/scala_210/lift_mvc/project/plugins.sbt
+++ b/scala_210/lift_mvc/project/plugins.sbt
@@ -1,13 +1,7 @@
-libraryDependencies <+= sbtVersion(v => v match {
-  case "0.11.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.0-0.2.8"
-  case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
-  case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
-  case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-})
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.3.0")
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")

--- a/scala_29/lift_basic/build.sbt
+++ b/scala_29/lift_basic/build.sbt
@@ -11,18 +11,18 @@ resolvers ++= Seq("snapshots"     at "http://oss.sonatype.org/content/repositori
                   "releases"      at "http://oss.sonatype.org/content/repositories/releases"
                  )
 
-seq(com.github.siasia.WebPlugin.webSettings :_*)
+seq(webSettings :_*)
 
 unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp" }
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5"
+  val liftVersion = "2.5.1"
   Seq(
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
     "net.liftweb"       %% "lift-mapper"        % liftVersion        % "compile",
-    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.3",
+    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_29/lift_basic/project/build.properties
+++ b/scala_29/lift_basic/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.12.2
+sbt.version=0.12.4
 

--- a/scala_29/lift_basic/project/plugins.sbt
+++ b/scala_29/lift_basic/project/plugins.sbt
@@ -1,13 +1,7 @@
-libraryDependencies <+= sbtVersion(v => v match {
-  case "0.11.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.0-0.2.8"
-  case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
-  case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
-  case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-})
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.3.0")
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")

--- a/scala_29/lift_basic/src/test/scala/code/snippet/HelloWorldTest.scala
+++ b/scala_29/lift_basic/src/test/scala/code/snippet/HelloWorldTest.scala
@@ -9,10 +9,10 @@ import Helpers._
 import lib._
 import org.specs2.mutable.Specification
 import org.specs2.specification.AroundExample
-import org.specs2.execute.AsResult
+import org.specs2.execute.Result
 
 
-object HelloWorldTestSpecs extends Specification with AroundExample{
+object HelloWorldTestSpecs extends Specification with AroundExample {
   val session = new LiftSession("", randomString(20), Empty)
   val stableTime = now
 
@@ -20,10 +20,10 @@ object HelloWorldTestSpecs extends Specification with AroundExample{
    * For additional ways of writing tests,
    * please see http://www.assembla.com/spaces/liftweb/wiki/Mocking_HTTP_Requests
    */
-  def around[T : AsResult](body: =>T) = {
+  def around[T <% Result](body: =>T) = {
     S.initIfUninitted(session) {
       DependencyFactory.time.doWith(stableTime) {
-        AsResult( body)  // execute t inside a http session
+        body // execute t inside a http session
       }
     }
   }

--- a/scala_29/lift_blank/build.sbt
+++ b/scala_29/lift_blank/build.sbt
@@ -10,17 +10,17 @@ resolvers ++= Seq("snapshots"     at "http://oss.sonatype.org/content/repositori
                 "releases"        at "http://oss.sonatype.org/content/repositories/releases"
                 )
 
-seq(com.github.siasia.WebPlugin.webSettings :_*)
+seq(webSettings :_*)
 
 unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp" }
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5"
+  val liftVersion = "2.5.1"
   Seq(
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
-    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.3",
+    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_29/lift_blank/project/build.properties
+++ b/scala_29/lift_blank/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.12.2
+sbt.version=0.12.4
 

--- a/scala_29/lift_blank/project/plugins.sbt
+++ b/scala_29/lift_blank/project/plugins.sbt
@@ -1,13 +1,7 @@
-libraryDependencies <+= sbtVersion(v => v match {
-  case "0.11.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.0-0.2.8"
-  case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
-  case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
-  case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-})
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.3.0")
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")

--- a/scala_29/lift_blank/src/test/scala/code/snippet/HelloWorldTest.scala
+++ b/scala_29/lift_blank/src/test/scala/code/snippet/HelloWorldTest.scala
@@ -9,10 +9,10 @@ import Helpers._
 import lib._
 import org.specs2.mutable.Specification
 import org.specs2.specification.AroundExample
-import org.specs2.execute.AsResult
+import org.specs2.execute.Result
 
 
-object HelloWorldTestSpecs extends Specification with AroundExample{
+object HelloWorldTestSpecs extends Specification with AroundExample {
   val session = new LiftSession("", randomString(20), Empty)
   val stableTime = now
 
@@ -20,10 +20,10 @@ object HelloWorldTestSpecs extends Specification with AroundExample{
    * For additional ways of writing tests,
    * please see http://www.assembla.com/spaces/liftweb/wiki/Mocking_HTTP_Requests
    */
-  def around[T : AsResult](body: =>T) = {
+  def around[T <% Result](body: =>T) = {
     S.initIfUninitted(session) {
       DependencyFactory.time.doWith(stableTime) {
-        AsResult( body)  // execute t inside a http session
+        body // execute t inside a http session
       }
     }
   }

--- a/scala_29/lift_json/build.sbt
+++ b/scala_29/lift_json/build.sbt
@@ -13,7 +13,7 @@ resolvers ++= Seq("snapshots"     at "http://oss.sonatype.org/content/repositori
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5"
+  val liftVersion = "2.5.1"
   Seq(
     "net.liftweb"       %% "lift-json"          % liftVersion % "compile",
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_29/lift_json/project/build.properties
+++ b/scala_29/lift_json/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.12.2
+sbt.version=0.12.4
 

--- a/scala_29/lift_json/project/plugins.sbt
+++ b/scala_29/lift_json/project/plugins.sbt
@@ -1,13 +1,7 @@
-libraryDependencies <+= sbtVersion(v => v match {
-  case "0.11.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.0-0.2.8"
-  case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
-  case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
-  case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-})
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.3.0")
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")

--- a/scala_29/lift_mvc/build.sbt
+++ b/scala_29/lift_mvc/build.sbt
@@ -10,18 +10,18 @@ resolvers ++= Seq("snapshots"     at "http://oss.sonatype.org/content/repositori
                 "releases"        at "http://oss.sonatype.org/content/repositories/releases"
                 )
 
-seq(com.github.siasia.WebPlugin.webSettings :_*)
+seq(webSettings :_*)
 
 unmanagedResourceDirectories in Test <+= (baseDirectory) { _ / "src/main/webapp" }
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
 libraryDependencies ++= {
-  val liftVersion = "2.5"
+  val liftVersion = "2.5.1"
   Seq(
     "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
     "net.liftweb"       %% "lift-mapper"        % liftVersion        % "compile",
-    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.3",
+    "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",

--- a/scala_29/lift_mvc/project/build.properties
+++ b/scala_29/lift_mvc/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.12.2
+sbt.version=0.12.4
 

--- a/scala_29/lift_mvc/project/plugins.sbt
+++ b/scala_29/lift_mvc/project/plugins.sbt
@@ -1,13 +1,7 @@
-libraryDependencies <+= sbtVersion(v => v match {
-  case "0.11.0" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.0-0.2.8"
-  case "0.11.1" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.1-0.2.10"
-  case "0.11.2" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.2-0.2.10"
-  case "0.11.3" => "com.github.siasia" %% "xsbt-web-plugin" % "0.11.3-0.2.11.1"
-  case x if x startsWith "0.12" => "com.github.siasia" %% "xsbt-web-plugin" % "0.12.0-0.2.11.1"
-})
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.3.0")
 
 //Enable the sbt idea plugin
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")
 
 //Enable the sbt eclipse plugin
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")


### PR DESCRIPTION
Offered for your consideration...
## Version changes
- Lift 2.5 -> 2.5.1
- jQuery Module 2.3 -> 2.4
- SBT 12.4
- IntelliJ SBT plugin to latest version
- Eclipse SBT plugin to latest version
- SBT web plugin using new recommended `addSbtPlugin` syntax, and shorted settings in _build.sbt_
## Fix

In testing my changes, I noticed that the _scala_29_ unit test was failing because of a difference between Specs2 for Scala 2.9 and 2.10: `AsResult` is in Specs2 for Scala 2.10.  Fixed by going back to `Result`.
