### PR TITLE
Bumping logback version to 1.2.3 for a security vulnerability fix

### DIFF
--- a/scala_210/lift_basic/build.sbt
+++ b/scala_210/lift_basic/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= {
     "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
-    "ch.qos.logback"    % "logback-classic"     % "1.0.6",
+    "ch.qos.logback"    % "logback-classic"     % "1.2.3",
     "org.specs2"        %% "specs2"             % "1.14"             % "test",
     "com.h2database"    % "h2"                  % "1.3.167"
   )

--- a/scala_210/lift_blank/build.sbt
+++ b/scala_210/lift_blank/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= {
     "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
-    "ch.qos.logback"    % "logback-classic"     % "1.0.6",
+    "ch.qos.logback"    % "logback-classic"     % "1.2.3",
     "org.specs2"        %% "specs2"             % "1.14"            % "test"
   )
 }

--- a/scala_210/lift_json/build.sbt
+++ b/scala_210/lift_json/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= {
   val liftVersion = "2.5.3"
   Seq(
     "net.liftweb"       %% "lift-json"          % liftVersion % "compile",
-    "ch.qos.logback"    % "logback-classic"     % "1.0.6",
+    "ch.qos.logback"    % "logback-classic"     % "1.2.3",
     "org.specs2"        %% "specs2"             % "1.14"      % "test"
   )
 }

--- a/scala_210/lift_mvc/build.sbt
+++ b/scala_210/lift_mvc/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= {
     "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
-    "ch.qos.logback"    % "logback-classic"     % "1.0.6",
+    "ch.qos.logback"    % "logback-classic"     % "1.2.3",
     "org.specs2"        %% "specs2"             % "1.14"             % "test",
     "com.h2database"    % "h2"                  % "1.3.167"
   )

--- a/scala_29/lift_basic/build.sbt
+++ b/scala_29/lift_basic/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= {
     "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
-    "ch.qos.logback"    % "logback-classic"     % "1.0.6",
+    "ch.qos.logback"    % "logback-classic"     % "1.2.3",
     "org.specs2"        %% "specs2"             % "1.12.1"             % "test",
     "com.h2database"    % "h2"                  % "1.3.167"
   )

--- a/scala_29/lift_blank/build.sbt
+++ b/scala_29/lift_blank/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= {
     "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
-    "ch.qos.logback"    % "logback-classic"     % "1.0.6",
+    "ch.qos.logback"    % "logback-classic"     % "1.2.3",
     "org.specs2"        %% "specs2"             % "1.12.1"            % "test"
   )
 }

--- a/scala_29/lift_json/build.sbt
+++ b/scala_29/lift_json/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= {
   val liftVersion = "2.5.3"
   Seq(
     "net.liftweb"       %% "lift-json"          % liftVersion % "compile",
-    "ch.qos.logback"    % "logback-classic"     % "1.0.6",
+    "ch.qos.logback"    % "logback-classic"     % "1.2.3",
     "org.specs2"        %% "specs2"             % "1.12.1"      % "test"
   )
 }

--- a/scala_29/lift_mvc/build.sbt
+++ b/scala_29/lift_mvc/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= {
     "net.liftmodules"   %% "lift-jquery-module_2.5" % "2.4",
     "org.eclipse.jetty" % "jetty-webapp"        % "8.1.7.v20120910"  % "container,test",
     "org.eclipse.jetty.orbit" % "javax.servlet" % "3.0.0.v201112011016" % "container,test" artifacts Artifact("javax.servlet", "jar", "jar"),
-    "ch.qos.logback"    % "logback-classic"     % "1.0.6",
+    "ch.qos.logback"    % "logback-classic"     % "1.2.3",
     "org.specs2"        %% "specs2"             % "1.12.1"             % "test",
     "com.h2database"    % "h2"                  % "1.3.167"
   )


### PR DESCRIPTION
Each project is now configured to utilize logback `1.2.3` to avoid a known security vulnerability.

Vulnerability details: https://nvd.nist.gov/vuln/detail/CVE-2017-5929
Related play framework security advisory: https://www.playframework.com/security/vulnerability/20170407-LogbackDeser